### PR TITLE
Add Granola integration with meeting-sync skill

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -136,6 +136,16 @@ The system automatically:
 4. **Prune completed tasks** - Auto-cleanup after 30 days
 5. **Link related items** - Connect tasks to CRM contacts
 
+## Integrations
+
+Optional integrations extend Personal OS with external tools:
+
+| Integration | Description | Setup |
+|-------------|-------------|-------|
+| [Granola](./integrations/granola/) | Sync meeting notes and transcripts | `Set up Granola integration` |
+
+See [integrations/](./integrations/) for full documentation.
+
 ## Customization
 
 The system is designed to be extended:
@@ -143,7 +153,7 @@ The system is designed to be extended:
 - **Categories**: Add your own in config.yaml
 - **Priorities**: Define what's urgent for you
 - **Workflows**: Modify AGENTS.md instructions
-- **Integrations**: Extend MCP server with new tools
+- **Integrations**: Add external tools via [integrations/](./integrations/)
 
 ## Example Workflow
 

--- a/core/integrations/README.md
+++ b/core/integrations/README.md
@@ -1,0 +1,37 @@
+# Integrations
+
+Optional integrations that extend Personal OS with external tools.
+
+## Available Integrations
+
+| Integration | Description | Setup |
+|-------------|-------------|-------|
+| [Granola](./granola/) | Sync meeting notes and transcripts | `Set up Granola integration` |
+
+## Adding Integrations
+
+Each integration folder contains:
+
+- `README.md` - Full documentation and manual setup
+- `SETUP_SKILL.md` - Skill template for automated installation
+- `mcp-config.json` - MCP server configuration template
+
+## Using Integrations
+
+Most integrations can be set up by telling Claude:
+
+```
+Set up [integration name] for my Personal OS
+```
+
+Claude will follow the setup skill to install and configure everything.
+
+## Contributing
+
+To add a new integration:
+
+1. Create a folder under `core/integrations/`
+2. Add `README.md` with documentation
+3. Add `SETUP_SKILL.md` with installation steps
+4. Add any config templates needed
+5. Update this README with the new integration

--- a/core/integrations/granola/README.md
+++ b/core/integrations/granola/README.md
@@ -1,0 +1,201 @@
+# Granola Integration
+
+Sync your [Granola.ai](https://granola.ai) meeting notes and transcripts into your Personal OS Knowledge folder.
+
+## What This Does
+
+- **Search meetings** by title, participants, or content
+- **Sync meeting notes** to your local `Knowledge/Transcripts/` folder
+- **Morning planning** includes recent meeting context
+- **Pattern analysis** across your meetings (topics, frequency, participants)
+
+## Prerequisites
+
+1. **Granola.ai** installed and running on macOS
+2. **Python 3.12+** installed
+3. **uv** package manager (`brew install uv` or `pip install uv`)
+
+## Quick Setup
+
+Tell Claude:
+
+```
+Set up Granola integration for my Personal OS
+```
+
+Claude will:
+1. Clone the Granola MCP server
+2. Configure your `.mcp.json`
+3. Verify the connection works
+
+## Manual Installation
+
+### Step 1: Clone the Granola MCP Server
+
+```bash
+cd ~/Projects  # or wherever you keep repos
+git clone https://github.com/proofgeist/granola-ai-mcp-server.git
+cd granola-ai-mcp-server
+uv sync
+```
+
+### Step 2: Test the Server
+
+```bash
+uv run python test_server.py
+```
+
+### Step 3: Add to `.mcp.json`
+
+Add this to your project's `.mcp.json` file:
+
+```json
+{
+  "mcpServers": {
+    "granola": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/absolute/path/to/granola-ai-mcp-server",
+        "run",
+        "granola-mcp-server"
+      ],
+      "env": {
+        "KNOWLEDGE_PATH": "/absolute/path/to/your/personal-os/Knowledge"
+      }
+    }
+  }
+}
+```
+
+Replace the paths with your actual locations.
+
+### Step 4: Create Transcripts Folder
+
+```bash
+mkdir -p Knowledge/Transcripts
+```
+
+### Step 5: Install Skills
+
+Copy the included skills to your Claude skills folder:
+
+```bash
+cp -r core/integrations/granola/skills/* .claude/skills/
+```
+
+This adds:
+- **meeting-sync** - Guided workflow for syncing meetings
+
+### Step 6: Restart Claude Code
+
+Restart your Claude Code session to load the new MCP server.
+
+## Included Skills
+
+### meeting-sync
+
+Triggered by: "Sync my meetings", "What should I do today?", or during morning planning.
+
+What it does:
+1. Checks for new unsynced Granola meetings
+2. Presents them to you with sync options
+3. Exports selected meetings to `Knowledge/Transcripts/`
+4. Continues with your normal workflow
+
+To install manually:
+```bash
+cp -r core/integrations/granola/skills/meeting-sync .claude/skills/
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_meetings` | Search by title, content, or participants |
+| `get_meeting_details` | Get full meeting metadata |
+| `get_meeting_transcript` | Retrieve the transcript |
+| `check_new_meetings` | List meetings not yet synced |
+| `sync_meeting_to_local` | Export meeting to Knowledge folder |
+| `analyze_meeting_patterns` | Analyze topics, frequency, participants |
+| `get_last_sync_time` | Check when you last synced |
+| `reset_sync` | Re-sync meetings from past N days |
+
+## Example Usage
+
+### Sync new meetings
+
+```
+Sync my Granola meetings
+```
+
+### Search for a topic
+
+```
+Search my meetings for "product roadmap"
+```
+
+### Morning planning with meetings
+
+```
+What should I work on today?
+```
+
+This automatically checks for new meetings and incorporates recent context.
+
+### Analyze patterns
+
+```
+Who have I been meeting with most this month?
+```
+
+## How Syncing Works
+
+1. `check_new_meetings` compares Granola cache against `.granola-sync.json`
+2. `sync_meeting_to_local` exports selected meetings as markdown
+3. Files are saved to `Knowledge/Transcripts/YYYY-MM-DD_meeting-title.md`
+4. Sync state is tracked so meetings aren't duplicated
+
+## Troubleshooting
+
+### "No Granola cache found"
+
+Make sure Granola is installed and you've attended at least one meeting. The cache lives at:
+```
+~/Library/Application Support/Granola/cache-v3.json
+```
+
+### "uv: command not found"
+
+Install uv:
+```bash
+brew install uv
+# or
+pip install uv
+```
+
+### MCP server not connecting
+
+1. Check the path in `.mcp.json` is absolute
+2. Verify `uv sync` ran successfully in the granola-mcp-server folder
+3. Restart Claude Code
+
+### Meetings show "(no notes)"
+
+Some calendar events in Granola don't have meeting content. These are typically placeholder events or meetings you didn't record.
+
+## Related Skills
+
+- **meeting-sync** - Sync workflow with user prompts
+- **morning-planning** - Includes meeting check in daily planning
+
+## Privacy
+
+- All data stays local on your machine
+- The MCP server reads from Granola's local cache only
+- No external API calls are made
+- Your transcripts are never sent anywhere
+
+## Credits
+
+MCP Server: [proofgeist/granola-ai-mcp-server](https://github.com/proofgeist/granola-ai-mcp-server)

--- a/core/integrations/granola/SETUP_SKILL.md
+++ b/core/integrations/granola/SETUP_SKILL.md
@@ -1,0 +1,167 @@
+# Setup Granola Integration Skill
+
+Copy this to `.claude/skills/setup-granola/SKILL.md` to enable automatic installation.
+
+---
+
+```markdown
+---
+name: setup-granola
+description: Install and configure Granola MCP server for meeting sync. Use when user says "set up Granola", "install Granola integration", or "connect Granola".
+---
+
+# Setup Granola Integration
+
+Automatically install and configure the Granola MCP server for syncing meetings to Personal OS.
+
+## Prerequisites Check
+
+Before starting, verify:
+1. User is on macOS (Granola is macOS only)
+2. User has Granola.ai installed
+3. Python 3.12+ is available
+4. uv is installed (or can be installed)
+
+## Instructions
+
+### Step 1: Check Prerequisites
+
+Run these checks and report any issues:
+
+```bash
+# Check OS
+uname -s  # Should be Darwin
+
+# Check Python version
+python3 --version  # Should be 3.12+
+
+# Check uv
+uv --version  # Install if missing: brew install uv
+
+# Check if Granola cache exists
+ls ~/Library/Application\ Support/Granola/cache-v3.json
+```
+
+If uv is missing, offer to install it:
+```bash
+brew install uv
+```
+
+If Granola cache doesn't exist, inform user they need to:
+1. Install Granola from https://granola.ai
+2. Attend or record at least one meeting
+
+### Step 2: Clone MCP Server
+
+Ask user where to clone (suggest ~/Projects):
+
+```bash
+cd ~/Projects  # or user's preferred location
+git clone https://github.com/proofgeist/granola-ai-mcp-server.git
+cd granola-ai-mcp-server
+uv sync
+```
+
+### Step 3: Test Server
+
+Verify installation works:
+
+```bash
+cd ~/Projects/granola-ai-mcp-server
+uv run python test_server.py
+```
+
+### Step 4: Create Transcripts Folder
+
+```bash
+mkdir -p Knowledge/Transcripts
+```
+
+### Step 5: Install Skills
+
+Copy the Granola skills to the user's Claude skills folder:
+
+```bash
+mkdir -p .claude/skills/meeting-sync
+cp core/integrations/granola/skills/meeting-sync/SKILL.md .claude/skills/meeting-sync/
+```
+
+### Step 6: Update .mcp.json
+
+Read the current `.mcp.json` file and add the granola server config.
+
+The config should be:
+
+```json
+{
+  "mcpServers": {
+    "granola": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "<GRANOLA_MCP_PATH>",
+        "run",
+        "granola-mcp-server"
+      ],
+      "env": {
+        "KNOWLEDGE_PATH": "<PERSONAL_OS_PATH>/Knowledge"
+      }
+    }
+  }
+}
+```
+
+Replace:
+- `<GRANOLA_MCP_PATH>` with absolute path to granola-ai-mcp-server
+- `<PERSONAL_OS_PATH>` with absolute path to personal-os workspace
+
+### Step 7: Verify Setup
+
+Ask user to restart Claude Code, then test:
+
+```
+Search my meetings for "test"
+```
+
+or
+
+```
+Check for new Granola meetings
+```
+
+## Success Criteria
+
+- [ ] Prerequisites verified
+- [ ] granola-ai-mcp-server cloned and dependencies installed
+- [ ] test_server.py passes
+- [ ] Knowledge/Transcripts folder exists
+- [ ] meeting-sync skill installed to .claude/skills/
+- [ ] .mcp.json updated with granola config
+- [ ] Claude Code restarted
+- [ ] Granola tools accessible (search_meetings works)
+
+## Troubleshooting
+
+### Python version too old
+```bash
+brew install python@3.12
+```
+
+### uv sync fails
+```bash
+pip install uv  # Alternative installation
+```
+
+### Permission denied on cache
+Granola must be running with proper permissions. User should open Granola app once.
+
+### MCP not loading
+Check .mcp.json syntax and ensure paths are absolute (not relative).
+
+## After Setup
+
+Inform user they can now:
+- Say "Sync my Granola meetings" to sync new meetings
+- Morning planning will automatically check for new meetings
+- Search across all meeting content
+```

--- a/core/integrations/granola/mcp-config.json
+++ b/core/integrations/granola/mcp-config.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "granola": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/path/to/granola-ai-mcp-server",
+        "run",
+        "granola-mcp-server"
+      ],
+      "env": {
+        "KNOWLEDGE_PATH": "/path/to/personal-os/Knowledge"
+      }
+    }
+  }
+}

--- a/core/integrations/granola/skills/meeting-sync/SKILL.md
+++ b/core/integrations/granola/skills/meeting-sync/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: meeting-sync
+description: Sync new Granola meetings to local Knowledge folder. Use during morning planning, when user asks "what should I do today", or asks to review/sync meetings.
+---
+
+# Meeting Sync
+
+Check for new Granola meetings and offer to sync them to your local Knowledge/Transcripts folder.
+
+## Instructions
+
+### Step 1: Check for New Meetings
+
+Call the `check_new_meetings` tool via the Granola MCP to see unsynced meetings.
+
+### Step 2: Present Results
+
+If new meetings are found, present them to the user:
+
+```
+I found X new meeting(s) since your last sync:
+
+1. **Meeting Title** (Date)
+2. **Meeting Title** (Date)
+...
+
+Add to Knowledge folder?
+```
+
+### Step 3: Ask User for Selection
+
+Use AskUserQuestion with these options:
+
+| Option | Description |
+|--------|-------------|
+| Sync all | Add all new meetings to Knowledge/Transcripts |
+| Select specific | Let user choose which meetings to sync |
+| Skip for now | Continue without syncing |
+
+### Step 4: Sync Selected Meetings
+
+For each meeting the user wants to sync:
+1. Call `sync_meeting_to_local` with the meeting ID
+2. Confirm each sync completed
+
+### Step 5: Continue with Morning Flow
+
+After syncing (or skipping), continue with the normal morning planning workflow:
+- Check tasks
+- Review priorities
+- Suggest focus items for the day
+
+## Example Flow
+
+**User:** "What should I do today?"
+
+**Claude:**
+1. Calls `check_new_meetings`
+2. "I found 3 new meetings since your last sync..."
+3. Presents AskUserQuestion with sync options
+4. User selects "Sync all" or specific meetings
+5. Syncs selected meetings
+6. "Synced 3 meetings. Now for your day..."
+7. Continues with task planning
+
+## Notes
+
+- Only Granola meetings with notes/content are worth syncing
+- Meetings marked "(no notes)" may be empty placeholders
+- Sync state is tracked in `Knowledge/.granola-sync.json`
+- Files are saved to `Knowledge/Transcripts/` with sanitized filenames


### PR DESCRIPTION
## Summary

- Add integrations folder structure under `core/integrations/`
- Granola integration includes:
  - Full documentation with manual setup steps
  - Setup skill template for automated Claude-assisted installation
  - MCP config template
  - `meeting-sync` skill for syncing meetings to Knowledge folder

## What this enables

Users can say:
- "Set up Granola integration" - Claude follows the setup skill to install
- "Sync my meetings" - Uses the meeting-sync skill to sync Granola meetings

## Files added

```
core/integrations/
├── README.md                              # Integration system overview
└── granola/
    ├── README.md                          # Full docs + manual setup
    ├── SETUP_SKILL.md                     # Skill template for auto-install
    ├── mcp-config.json                    # MCP config template
    └── skills/
        └── meeting-sync/
            └── SKILL.md                   # The meeting sync skill
```

## Test plan

- [ ] Review documentation for clarity
- [ ] Verify MCP config template is correct
- [ ] Test meeting-sync skill installation